### PR TITLE
bugfix inverted transformations accidentally modify original patterns

### DIFF
--- a/Source/lib/gfxp.lua
+++ b/Source/lib/gfxp.lua
@@ -318,6 +318,7 @@ GFXP._transformByFlag = function (val)
 	local flags = string.match(val, '[0-9]([irt]+)$')
 	local suffix = 1
 	local pattern = nil
+	local clone = nil
 	
 	if (not flags) then
 		-- Pattern w/o id,'name-irt'
@@ -330,11 +331,13 @@ GFXP._transformByFlag = function (val)
 		pattern = GFXP.lib[val:sub(1, -(#flags + suffix))]
 
 		if (pattern) then
-
+			clone = table.shallowcopy(pattern)
+			
 			for flag in string.gmatch(flags, '%w') do
-				GFXP._transformations[flag](pattern)
+				GFXP._transformations[flag](clone)
 			end
 
+			pattern = clone
 		end
 	end
 


### PR DESCRIPTION
Problem: Can't use "original" and "inverted" patterns at the same time. Additionally, once an inverted pattern is used the original can no longer be used.

I ran into this bug when trying to use an original and inverted pattern at the same time. 
The `GFXP._transformations` was accidentally modifying the original patterns because it had a direct reference to the `GFXP.lib`

This fix creates a clone of the original pattern before the transformation (then passes the transformed pattern back up to `GFXP.set` to be added to the `GFXP.lib` if `caching` is `true`)

You can recreate this bug with this simple app
```import 'CoreLibs/graphics'
import 'lib/gfxp'

local pd <const> = playdate
local gfx <const> = pd.graphics
local gfxp <const> = GFXP

function pd.update()
	gfxp.set('brick-4')
	gfx.fillRect(200 - 50, 120 - 25, 50, 50)
	
	gfxp.set('brick-4i')
	gfx.fillRect(200 + 25, 120 - 25, 50, 50)
end
```

**Before bugfix**
![gfxp-before-bugfix](https://user-images.githubusercontent.com/1278413/192682851-8fe6b2c5-9667-4feb-91cb-0d22653a6929.png)


**After bugfix**
![gfxp-after-bugfix](https://user-images.githubusercontent.com/1278413/192682863-6d71ebe3-2666-40da-bf73-a6cd531e003e.png)